### PR TITLE
Remove Go 1.11.x from tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   Build:
     strategy:
       matrix:
-        go-version: [1.11.x, 1.14.x]
+        go-version: [1.14.x]
         platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
They just fail on 1.11.x now anyway ¯\\\_(ツ)\_/¯