### PR TITLE
Allow case-insensitive authScheme to ensure RFC2617 compliance

### DIFF
--- a/jwt.go
+++ b/jwt.go
@@ -181,7 +181,7 @@ func jwtFromHeader(header string, authScheme string) func(c *fiber.Ctx) (string,
 	return func(c *fiber.Ctx) (string, error) {
 		auth := c.Get(header)
 		l := len(authScheme)
-		if len(auth) > l+1 && auth[:l] == authScheme {
+		if len(auth) > l+1 && strings.EqualFold(auth[:l], authScheme) {
 			return auth[l+1:], nil
 		}
 		return "", errors.New("Missing or malformed JWT")


### PR DESCRIPTION
Based on the RFC2617 (https://tools.ietf.org/html/rfc2617#section-1.2) the auth scheme token must be case-insensitive. Although it is not a common case, it might result in misbehavior of some older frameworks that are e.g. lower-case first.