### PR TITLE
Use golang-jwt/jwt instead of form3tech-oss/jwt-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This middleware supports Fiber v1 & v2, install accordingly.
 ```
 go get -u github.com/gofiber/fiber/v2
 go get -u github.com/gofiber/jwt/v2
-go get -u github.com/form3tech-oss/jwt-go
+go get -u github.com/golang-jwt/jwt
 ```
 
 ### Signature
@@ -52,8 +52,8 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 
-	jwt "github.com/form3tech-oss/jwt-go"
 	jwtware "github.com/gofiber/jwt/v2"
+	"github.com/golang-jwt/jwt"
 )
 
 func main() {
@@ -150,8 +150,8 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 
-	jwt "github.com/form3tech-oss/jwt-go"
 	jwtware "github.com/gofiber/jwt/v2"
+	"github.com/golang-jwt/jwt"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/gofiber/jwt/v2
 go 1.14
 
 require (
-	github.com/form3tech-oss/jwt-go v3.2.3+incompatible
 	github.com/gofiber/fiber/v2 v2.13.0
+	github.com/golang-jwt/jwt v3.2.1+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 github.com/andybalholm/brotli v1.0.2 h1:JKnhI/XQ75uFBTiuzXpzFrUriDPiZjlOSzh6wXogP0E=
 github.com/andybalholm/brotli v1.0.2/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
-github.com/form3tech-oss/jwt-go v3.2.3+incompatible h1:7ZaBxOI7TMoYBfyA3cQHErNNyAWIKUMIwqxEtgHOs5c=
-github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/gofiber/fiber/v2 v2.13.0 h1:jJBCPwq+hlsfHRDVsmfu6pbgW85Y8jL9dE+VmTzfE6I=
 github.com/gofiber/fiber/v2 v2.13.0/go.mod h1:oZTLWqYnqpMMuF922SjGbsYZsdpE1MCfh416HNdweIM=
+github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=
+github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/klauspost/compress v1.12.2 h1:2KCfW3I9M7nSc5wOqXAlW2v2U6v+w6cbjvbfp+OykW8=
 github.com/klauspost/compress v1.12.2/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=

--- a/jwt.go
+++ b/jwt.go
@@ -11,8 +11,8 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/form3tech-oss/jwt-go"
 	"github.com/gofiber/fiber/v2"
+	"github.com/golang-jwt/jwt"
 )
 
 // Config defines the config for BasicAuth middleware


### PR DESCRIPTION
After the original author of the library `github.com/dgrijalva/jwt-go` suggested migrating the maintenance of `jwt-go`, a dedicated team of open source maintainers decided to clone the existing library into [https://github.com/golang-jwt/jwt].

See [dgrijalva/jwt-go#462] for a detailed discussion on this topic.