### PR TITLE
feat: add custom KeyFunc to middleware configuration

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,11 +48,11 @@ func New(config ...Config) fiber.Handler {
 		var token *jwt.Token
 
 		if _, ok := cfg.Claims.(jwt.MapClaims); ok {
-			token, err = jwt.Parse(auth, cfg.keyFunc)
+			token, err = jwt.Parse(auth, cfg.KeyFunc)
 		} else {
 			t := reflect.ValueOf(cfg.Claims).Type().Elem()
 			claims := reflect.New(t).Interface().(jwt.Claims)
-			token, err = jwt.ParseWithClaims(auth, claims, cfg.keyFunc)
+			token, err = jwt.ParseWithClaims(auth, claims, cfg.KeyFunc)
 		}
 		if err == nil && token.Valid {
 			// Store user information from token into context.


### PR DESCRIPTION
The JWT-Go package provide a config option to define a custom function that dynamically supply a signing key. This can be useful to load a user or client specific signing keys from database. The original echo middleware has also implemented this feature.

The KeyFunc is already used by the gofiber middleware itself to handle jwks and default signing key or keys but it was not possible to define a custom KeyFunc.

The PR makes the KeyFunc available in the Configuration struct to overwrite the default KeyFunc of the middleware.

Would be great if you could approve this PR.
