### PR TITLE
Feature/multiple jwks urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,27 +29,27 @@ jwtware.New(config ...jwtware.Config) func(*fiber.Ctx) error
 ```
 
 ### Config
-| Property                 | Type | Description | Default |
-|:-------------------------| :--- | :--- | :--- |
-| Filter                   | `func(*fiber.Ctx) bool` | Defines a function to skip middleware | `nil` |
-| SuccessHandler           | `func(*fiber.Ctx) error` |  SuccessHandler defines a function which is executed for a valid token. | `nil` |
-| ErrorHandler             | `func(*fiber.Ctx, error) error` | ErrorHandler defines a function which is executed for an invalid token. | `401 Invalid or expired JWT` |
-| SigningKey               | `interface{}` | Signing key to validate token. Used as fallback if SigningKeys has length 0. | `nil` |
-| SigningKeys              | `map[string]interface{}` | Map of signing keys to validate token with kid field usage. | `nil` |
+| Property                 | Type | Description                                                                                                                                          | Default |
+|:-------------------------| :--- |:-----------------------------------------------------------------------------------------------------------------------------------------------------| :--- |
+| Filter                   | `func(*fiber.Ctx) bool` | Defines a function to skip middleware                                                                                                                | `nil` |
+| SuccessHandler           | `func(*fiber.Ctx) error` | SuccessHandler defines a function which is executed for a valid token.                                                                               | `nil` |
+| ErrorHandler             | `func(*fiber.Ctx, error) error` | ErrorHandler defines a function which is executed for an invalid token.                                                                              | `401 Invalid or expired JWT` |
+| SigningKey               | `interface{}` | Signing key to validate token. Used as fallback if SigningKeys has length 0.                                                                         | `nil` |
+| SigningKeys              | `map[string]interface{}` | Map of signing keys to validate token with kid field usage.                                                                                          | `nil` |
 | SigningMethod            | `string` | Signing method, used to check token signing method. Possible values: `HS256`, `HS384`, `HS512`, `ES256`, `ES384`, `ES512`, `RS256`, `RS384`, `RS512` | `"HS256"` |
-| ContextKey               | `string` | Context key to store user information from the token into context. | `"user"` |
-| Claims                   | `jwt.Claim` | Claims are extendable claims data defining token content. | `jwt.MapClaims{}` |
-| TokenLookup              | `string` | TokenLookup is a string in the form of `<source>:<name>` that is used | `"header:Authorization"` |
-| AuthScheme               | `string` |AuthScheme to be used in the Authorization header. | `"Bearer"` |
-| KeySetURL(deprecated)    | `string` |KeySetURL location of JSON file with signing keys. | `""` |
-| KeySetURLs               | `string` |KeySetURL location of JSON file with signing keys. | `""` |
-| KeyRefreshSuccessHandler | `func(j *KeySet)` |KeyRefreshSuccessHandler defines a function which is executed for a valid refresh of signing keys.| `nil` |
-| KeyRefreshErrorHandler   | `func(j *KeySet, err error)` |KeyRefreshErrorHandler defines a function which is executed for an invalid refresh of signing keys. | `nil` |
-| KeyRefreshInterval       | `*time.Duration` |KeyRefreshInterval is the duration to refresh the JWKs in the background via a new HTTP request. | `nil` |
-| KeyRefreshRateLimit      | `*time.Duration` |KeyRefreshRateLimit limits the rate at which refresh requests are granted.  | `nil` |
-| KeyRefreshTimeout        | `*time.Duration` |KeyRefreshTimeout is the duration for the context used to create the HTTP request for a refresh of the JWKs. | `1min` |
-| KeyRefreshUnknownKID     | `bool` |KeyRefreshUnknownKID indicates that the JWKs refresh request will occur every time a kid that isn't cached is seen. | `false` |
-| KeyFunc                  | `func() jwt.Keyfunc` |KeyFunc defines a user-defined function that supplies the public key for a token validation. | `jwtKeyFunc` |
+| ContextKey               | `string` | Context key to store user information from the token into context.                                                                                   | `"user"` |
+| Claims                   | `jwt.Claim` | Claims are extendable claims data defining token content.                                                                                            | `jwt.MapClaims{}` |
+| TokenLookup              | `string` | TokenLookup is a string in the form of `<source>:<name>` that is used                                                                                | `"header:Authorization"` |
+| AuthScheme               | `string` | AuthScheme to be used in the Authorization header.                                                                                                   | `"Bearer"` |
+| KeySetURL(deprecated)    | `string` | KeySetURL location of JSON file with signing keys.                                                                                                   | `""` |
+| KeySetURLs               | `string` | KeySetURL locations of JSON file with signing keys.                                                                                                  | `""` |
+| KeyRefreshSuccessHandler | `func(j *KeySet)` | KeyRefreshSuccessHandler defines a function which is executed for a valid refresh of signing keys.                                                   | `nil` |
+| KeyRefreshErrorHandler   | `func(j *KeySet, err error)` | KeyRefreshErrorHandler defines a function which is executed for an invalid refresh of signing keys.                                                  | `nil` |
+| KeyRefreshInterval       | `*time.Duration` | KeyRefreshInterval is the duration to refresh the JWKs in the background via a new HTTP request.                                                     | `nil` |
+| KeyRefreshRateLimit      | `*time.Duration` | KeyRefreshRateLimit limits the rate at which refresh requests are granted.                                                                           | `nil` |
+| KeyRefreshTimeout        | `*time.Duration` | KeyRefreshTimeout is the duration for the context used to create the HTTP request for a refresh of the JWKs.                                         | `1min` |
+| KeyRefreshUnknownKID     | `bool` | KeyRefreshUnknownKID indicates that the JWKs refresh request will occur every time a kid that isn't cached is seen.                                  | `false` |
+| KeyFunc                  | `func() jwt.Keyfunc` | KeyFunc defines a user-defined function that supplies the public key for a token validation.                                                         | `jwtKeyFunc` |
 
 
 ### HS256 Example

--- a/README.md
+++ b/README.md
@@ -29,26 +29,27 @@ jwtware.New(config ...jwtware.Config) func(*fiber.Ctx) error
 ```
 
 ### Config
-| Property | Type | Description | Default |
-| :--- | :--- | :--- | :--- |
-| Filter | `func(*fiber.Ctx) bool` | Defines a function to skip middleware | `nil` |
-| SuccessHandler | `func(*fiber.Ctx) error` |  SuccessHandler defines a function which is executed for a valid token. | `nil` |
-| ErrorHandler | `func(*fiber.Ctx, error) error` | ErrorHandler defines a function which is executed for an invalid token. | `401 Invalid or expired JWT` |
-| SigningKey | `interface{}` | Signing key to validate token. Used as fallback if SigningKeys has length 0. | `nil` |
-| SigningKeys | `map[string]interface{}` | Map of signing keys to validate token with kid field usage. | `nil` |
-| SigningMethod | `string` | Signing method, used to check token signing method. Possible values: `HS256`, `HS384`, `HS512`, `ES256`, `ES384`, `ES512`, `RS256`, `RS384`, `RS512` | `"HS256"` |
-| ContextKey | `string` | Context key to store user information from the token into context. | `"user"` |
-| Claims | `jwt.Claim` | Claims are extendable claims data defining token content. | `jwt.MapClaims{}` |
-| TokenLookup | `string` | TokenLookup is a string in the form of `<source>:<name>` that is used | `"header:Authorization"` |
-| AuthScheme | `string` |AuthScheme to be used in the Authorization header. | `"Bearer"` |
-| KeySetURL | `string` |KeySetURL location of JSON file with signing keys. | `""` |
+| Property                 | Type | Description | Default |
+|:-------------------------| :--- | :--- | :--- |
+| Filter                   | `func(*fiber.Ctx) bool` | Defines a function to skip middleware | `nil` |
+| SuccessHandler           | `func(*fiber.Ctx) error` |  SuccessHandler defines a function which is executed for a valid token. | `nil` |
+| ErrorHandler             | `func(*fiber.Ctx, error) error` | ErrorHandler defines a function which is executed for an invalid token. | `401 Invalid or expired JWT` |
+| SigningKey               | `interface{}` | Signing key to validate token. Used as fallback if SigningKeys has length 0. | `nil` |
+| SigningKeys              | `map[string]interface{}` | Map of signing keys to validate token with kid field usage. | `nil` |
+| SigningMethod            | `string` | Signing method, used to check token signing method. Possible values: `HS256`, `HS384`, `HS512`, `ES256`, `ES384`, `ES512`, `RS256`, `RS384`, `RS512` | `"HS256"` |
+| ContextKey               | `string` | Context key to store user information from the token into context. | `"user"` |
+| Claims                   | `jwt.Claim` | Claims are extendable claims data defining token content. | `jwt.MapClaims{}` |
+| TokenLookup              | `string` | TokenLookup is a string in the form of `<source>:<name>` that is used | `"header:Authorization"` |
+| AuthScheme               | `string` |AuthScheme to be used in the Authorization header. | `"Bearer"` |
+| KeySetURL(deprecated)    | `string` |KeySetURL location of JSON file with signing keys. | `""` |
+| KeySetURLs               | `string` |KeySetURL location of JSON file with signing keys. | `""` |
 | KeyRefreshSuccessHandler | `func(j *KeySet)` |KeyRefreshSuccessHandler defines a function which is executed for a valid refresh of signing keys.| `nil` |
-| KeyRefreshErrorHandler | `func(j *KeySet, err error)` |KeyRefreshErrorHandler defines a function which is executed for an invalid refresh of signing keys. | `nil` |
-| KeyRefreshInterval | `*time.Duration` |KeyRefreshInterval is the duration to refresh the JWKs in the background via a new HTTP request. | `nil` |
-| KeyRefreshRateLimit | `*time.Duration` |KeyRefreshRateLimit limits the rate at which refresh requests are granted.  | `nil` |
-| KeyRefreshTimeout | `*time.Duration` |KeyRefreshTimeout is the duration for the context used to create the HTTP request for a refresh of the JWKs. | `1min` |
-| KeyRefreshUnknownKID | `bool` |KeyRefreshUnknownKID indicates that the JWKs refresh request will occur every time a kid that isn't cached is seen. | `false` |
-| KeyFunc | `func() jwt.Keyfunc` |KeyFunc defines a user-defined function that supplies the public key for a token validation. | `jwtKeyFunc` |
+| KeyRefreshErrorHandler   | `func(j *KeySet, err error)` |KeyRefreshErrorHandler defines a function which is executed for an invalid refresh of signing keys. | `nil` |
+| KeyRefreshInterval       | `*time.Duration` |KeyRefreshInterval is the duration to refresh the JWKs in the background via a new HTTP request. | `nil` |
+| KeyRefreshRateLimit      | `*time.Duration` |KeyRefreshRateLimit limits the rate at which refresh requests are granted.  | `nil` |
+| KeyRefreshTimeout        | `*time.Duration` |KeyRefreshTimeout is the duration for the context used to create the HTTP request for a refresh of the JWKs. | `1min` |
+| KeyRefreshUnknownKID     | `bool` |KeyRefreshUnknownKID indicates that the JWKs refresh request will occur every time a kid that isn't cached is seen. | `false` |
+| KeyFunc                  | `func() jwt.Keyfunc` |KeyFunc defines a user-defined function that supplies the public key for a token validation. | `jwtKeyFunc` |
 
 
 ### HS256 Example
@@ -245,7 +246,7 @@ func restricted(c *fiber.Ctx) error {
 The RS256 is actually identical to the HS256 test above.
 
 ### JWKs Test
-The tests are identical to basic `JWT` tests above, with exception that `KeySetURL` to valid public keys collection in JSON format should be supplied.
+The tests are identical to basic `JWT` tests above, with exception that `KeySetURL`(deprecated) or `KeySetUrls` to valid public keys collection in JSON format should be supplied.
 
 ### Custom KeyFunc example
 

--- a/config.go
+++ b/config.go
@@ -138,10 +138,13 @@ func makeCfg(config []Config) (cfg Config) {
 			return c.Status(fiber.StatusUnauthorized).SendString("Invalid or expired JWT")
 		}
 	}
-	if cfg.SigningKey == nil && len(cfg.SigningKeys) == 0 && cfg.KeySetURL == "" && len(cfg.KeySetURLs) == 0 && cfg.KeyFunc == nil {
+	if cfg.KeySetURL != "" {
+		cfg.KeySetURLs = append(cfg.KeySetURLs, cfg.KeySetURL)
+	}
+	if cfg.SigningKey == nil && len(cfg.SigningKeys) == 0 && len(cfg.KeySetURLs) == 0 && cfg.KeyFunc == nil {
 		panic("Fiber: JWT middleware requires signing key or url where to download one")
 	}
-	if cfg.SigningMethod == "" && cfg.KeySetURL == "" && len(cfg.KeySetURLs) == 0 {
+	if cfg.SigningMethod == "" && len(cfg.KeySetURLs) == 0 {
 		cfg.SigningMethod = "HS256"
 	}
 	if cfg.ContextKey == "" {
@@ -159,11 +162,9 @@ func makeCfg(config []Config) (cfg Config) {
 	if cfg.KeyRefreshTimeout == nil {
 		cfg.KeyRefreshTimeout = &defaultKeyRefreshTimeout
 	}
-	if cfg.KeySetURL != "" {
-		cfg.KeySetURLs = append(cfg.KeySetURLs, cfg.KeySetURL)
-	}
+
 	if cfg.KeyFunc == nil {
-		if cfg.KeySetURL != "" || len(cfg.KeySetURLs) > 0 {
+		if len(cfg.KeySetURLs) > 0 {
 			jwks := &KeySet{
 				Config: &cfg,
 			}

--- a/jwks.go
+++ b/jwks.go
@@ -151,7 +151,7 @@ func (j *KeySet) getKey(kid string) (jsonKey *rawJWK, err error) {
 	// Check if the key was present.
 	if !ok {
 		// Check to see if configured to refresh on unknown kid.
-		if *j.Config.KeyRefreshUnknownKID {
+		if j.Config.KeyRefreshUnknownKID != nil && *j.Config.KeyRefreshUnknownKID {
 			// Create a context for refreshing the JWKs.
 			ctx, cancel := context.WithCancel(j.ctx)
 

--- a/jwks.go
+++ b/jwks.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"sync"
 	"time"
@@ -309,10 +310,14 @@ func (j *KeySet) refresh() (err error) {
 		// Read the raw JWKs from the body of the response.
 		var jwksBytes []byte
 		if jwksBytes, err = ioutil.ReadAll(resp.Body); err != nil {
-			resp.Body.Close() //manually close here
+			if cErr := resp.Body.Close(); cErr != nil {
+				log.Printf("error closing response body: %s", cErr.Error())
+			}
 			return err
 		}
-		resp.Body.Close() // ignore any error, don't use defer as we are in a for loop
+		if cErr := resp.Body.Close(); cErr != nil {
+			log.Printf("error closing response body: %s", cErr.Error())
+		}
 
 		// Create an updated JWKs.
 		if urlKeys, urlErr := parseKeySet(jwksBytes); urlErr != nil {


### PR DESCRIPTION
This PR includes two parts, one discovered while implementing the feature.

1. A fix for a nil deref bug where Config.KeyRefreshUnknownKID is checked when possibly nil.
2. The feature to add multiple keyset urls. I have encountered this personally when using Azure AD to auth machine users and Azure B2C to auth users. When similar key ids are encountered across urls they are overwritten in no guaranteed order(as of right now)