### PR TITLE
#103 Allow Header Extraction without AuthScheme #103

### DIFF
--- a/jwt.go
+++ b/jwt.go
@@ -36,7 +36,7 @@ func jwtFromHeader(header string, authScheme string) func(c *fiber.Ctx) (string,
 		auth := c.Get(header)
 		l := len(authScheme)
 		if len(auth) > l+1 && strings.EqualFold(auth[:l], authScheme) {
-			return auth[l+1:], nil
+			return strings.TrimSpace(auth[l:]), nil
 		}
 		return "", errors.New("Missing or malformed JWT")
 	}


### PR DESCRIPTION
When we have an empty AuthScheme we accidently crop the first character as it usually has a space. This PR suggest to trim the token instead of cropping with + 1